### PR TITLE
set camera to 0,0 in demo-template boilerplate

### DIFF
--- a/demos/demo-template/animations/010-intro.json
+++ b/demos/demo-template/animations/010-intro.json
@@ -5,8 +5,8 @@
       {
         "time": 0.0,
         "easing": "cubic-in-out",
-        "x": 640.0,
-        "y": 360.0,
+        "x": 0.0,
+        "y": 0.0,
         "magnitude": 720.0
       }
     ]


### PR DESCRIPTION
Camera was offset 50% from top left, which in the hands of careless observers (i.e. me) can lead to offsetting objects to compensate and then wonder why the camera roll is not dead center.